### PR TITLE
Update keycloak.json

### DIFF
--- a/keycloak.json
+++ b/keycloak.json
@@ -1,10 +1,10 @@
 {
   "realm": "Funcionarios",
-  "auth-server-url": "https://id-hml.dasa.com.br/auth/",
+  "auth-server-url": "https://id-hml.xxxx.com.br/auth/",
   "ssl-required": "external",
   "resource": "elofy",
   "credentials": {
-    "secret": "4700024e-075e-4caf-bdde-d1267316223a"
+    "secret": "XXXX"
   },
   "confidential-port": 0
 }


### PR DESCRIPTION
Please, remove dasa information.
https://github.com/dream-k/keycloak-ci/blob/5b2d03245ade84c8562a4e9adb7fc67821a41028/keycloak.json
{
  "realm": "Funcionarios",
  "auth-server-url": "https://id-hml.dasa.com.br/auth/",
  "ssl-required": "external",
  "resource": "elofy",
  "credentials": {
    "secret": "4700024e-075e-4caf-bdde-d1267316223a"
  },
  "confidential
